### PR TITLE
feat: limits the types to a smaler scope, and customizes descriptions

### DIFF
--- a/engine.test.js
+++ b/engine.test.js
@@ -4,7 +4,7 @@ var engine = require('./engine');
 var mock = require('mock-require');
 var semver = require('semver');
 
-var types = require('conventional-commit-types').types;
+var types = require('./types').types;
 
 var expect = chai.expect;
 chai.should();

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'format cjs';
 
 var engine = require('./engine');
-var conventionalCommitTypes = require('conventional-commit-types');
+var conventionalCommitTypes = require('./types');
 var configLoader = require('commitizen').configLoader;
 
 var config = configLoader.load();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalroute/cz-conventional-changelog-for-jira",
-  "version": "0.0.0-semantically-released.0",
+  "version": "0.0.0-semantically-released",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -517,7 +517,8 @@
     "conventional-commit-types": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
-      "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg=="
+      "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "commitizen": "^4.0.3",
-    "conventional-commit-types": "^3.0.0",
     "git-branch": "^2.0.1",
     "lodash.map": "^4.5.1",
     "longest": "^2.0.1",

--- a/types.js
+++ b/types.js
@@ -1,0 +1,43 @@
+module.exports = {
+  types: {
+    feat: {
+      description: 'A new feature',
+      title: 'Features'
+    },
+    fix: {
+      description: 'A bug fix',
+      title: 'Bug Fixes'
+    },
+    docs: {
+      description: 'Documentation only changes',
+      title: 'Documentation'
+    },
+    refactor: {
+      description:
+        'A code change that neither fixes a bug nor adds a feature (formatting, performance improvement, etc)',
+      title: 'Code Refactoring'
+    },
+    test: {
+      description: 'Adding missing tests or correcting existing tests',
+      title: 'Tests'
+    },
+    build: {
+      description:
+        'Changes that affect the build system or external dependencies (npm, webpack, typescript)',
+      title: 'Builds'
+    },
+    ci: {
+      description:
+        'Changes to our CI configuration files and scripts (NOTE: Does not bump the version)',
+      title: 'Continuous Integrations'
+    },
+    chore: {
+      description: "Other changes that don't modify src or test files",
+      title: 'Chores'
+    },
+    revert: {
+      description: 'Reverts a previous commit',
+      title: 'Reverts'
+    }
+  }
+};


### PR DESCRIPTION
This commit removes some commit types to make it easier to use for developers. The descriptions are
updated to include more relevant and modern scenarios. Like exchanging gulp for webpack as an
example of a bundling-/build-tool.

BREAKING CHANGE: Some types are not included any more: style, perf. refactor can be used instead