### PR TITLE
fix: Change JIRA issue RegExp

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -44,7 +44,7 @@ module.exports = function(options) {
   const maxHeaderWidth = getFromOptionsOrDefaults('maxHeaderWidth');
 
   const branchName = branch.sync() || '';
-  const jiraIssueRegex = /(?<jiraIssue>\/[A-Z]+-\d+)/;
+  const jiraIssueRegex = /(?<jiraIssue>(?<!([A-Z0-9]{1,10})-?)[A-Z0-9]+-\d+)/;
   const matchResult = branchName.match(jiraIssueRegex);
   const jiraIssue =
     matchResult && matchResult.groups && matchResult.groups.jiraIssue;
@@ -93,7 +93,7 @@ module.exports = function(options) {
           when: options.jiraMode,
           default: jiraIssue ? jiraIssue.substring(1) : '',
           validate: function(jira) {
-            return /^[A-Z]+-[0-9]+$/.test(jira);
+            return /^(?<!([A-Z0-9]{1,10})-?)[A-Z0-9]+-\d+$/.test(jira);
           },
           filter: function(jira) {
             return jira.toUpperCase();


### PR DESCRIPTION
Support for numbers in JIRA project code. 

We have JIRA project code like `AB3` so our task numbers are not valid (`AB3-1234`). 

I used improved regexp: https://community.atlassian.com/t5/Bitbucket-questions/Regex-pattern-to-match-JIRA-issue-key/qaq-p/233319, https://confluence.atlassian.com/stashkb/integrating-with-custom-jira-issue-key-313460921.html 