### PR TITLE
fix: stop removing first char from matched jira issue

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -91,7 +91,7 @@ module.exports = function(options) {
             getFromOptionsOrDefaults('jiraPrefix') +
             '-12345):',
           when: options.jiraMode,
-          default: jiraIssue ? jiraIssue.substring(1) : '',
+          default: jiraIssue || '',
           validate: function(jira) {
             return /^(?<!([A-Z0-9]{1,10})-?)[A-Z0-9]+-\d+$/.test(jira);
           },


### PR DESCRIPTION
@juliuscc you're the original author for this regex, since it has changed to not match for slashes thus the match will contain only the jira issue i.e `ABC-123` and not `/ABC-123` as before... any reason we had this in the matching group before?