### PR TITLE
feat: adds optional exclamation mark after scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Like commitizen, you can specify the configuration of cz-conventional-changelog-
 | CZ_JIRA_LOCATION     | jiraLocation   | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`                                                                               |
 | CZ_JIRA_PREPEND      | jiraPrepend    | ""                | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                        |
 | CZ_JIRA_APPEND       | jiraAppend     | ""                | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                         |
+| CZ_EXCLAMATION_MARK  | exclamationMark| false             | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1.  |
 
 ## Dynamic Configuration
 
@@ -120,6 +121,9 @@ List of all supported configurable options when using the _configurable_ approac
 | jiraLocation   | "pre-description"        | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`                                                                               |
 | jiraPrepend    | ""                       | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                        |
 | jiraAppend     | ""                       | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                         |
+| exclamationMark| false                    | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1.  |
+
+
 ### Commitlint
 
 If using the [commitlint](https://github.com/conventional-changelog/commitlint) js library, the "maxHeaderWidth" configuration property will default to the configuration of the "header-max-length" rule instead of the hard coded value of 72. This can be ovewritten by setting the 'maxHeaderWidth' configuration in package.json or the CZ_MAX_HEADER_WIDTH environment variable.

--- a/defaults.js
+++ b/defaults.js
@@ -11,5 +11,6 @@ module.exports = {
   jiraOptional: false,
   jiraLocation: 'pre-description',
   jiraPrepend: '',
-  jiraAppend: ''
+  jiraAppend: '',
+  exclamationMark: false
 };

--- a/engine.js
+++ b/engine.js
@@ -138,7 +138,7 @@ module.exports = function(options) {
           name: 'subject',
           message: 'Write a short, imperative tense description of the change:',
           default: options.defaultSubject,
-          maxLength: maxHeaderWidth,
+          maxLength: maxHeaderWidth - (options.exclamationMark ? 1 : 0),
           leadingLabel: answers => {
             const jira = answers.jira ? ` ${answers.jira}` : '';
             let scope = '';
@@ -226,6 +226,8 @@ module.exports = function(options) {
 
         // parentheses are only needed when a scope is present
         var scope = answers.scope ? '(' + answers.scope + ')' : '';
+        const addExclamationMark = options.exclamationMark && answers.breaking;
+        scope = addExclamationMark ? scope + '!' : scope;
 
         // Get Jira issue prepend and append decorators
         var prepend = options.jiraPrepend || ''

--- a/engine.test.js
+++ b/engine.test.js
@@ -238,6 +238,37 @@ describe('commit message', function() {
       `${type}(${scope}): ${jira} ${subject}\n\n${longBodySplit}\n\n${breakingChange}${breaking}\n\n${longIssuesSplit}`
     );
   });
+  it('header, body, breaking change, and issues w/ scope; exclamation mark enabled', function() {
+    expect(
+      commitMessage({
+        type,
+        scope,
+        jira,
+        subject,
+        body,
+        breaking,
+        issues
+      },
+        { ...defaultOptions, exclamationMark: true })
+    ).to.equal(
+      `${type}(${scope})!: ${jira} ${subject}\n\n${body}\n\n${breakingChange}${breaking}\n\n${issues}`
+    );
+  });
+  it('header, body, breaking change, and issues w/o scope; exclamation mark enabled', function() {
+    expect(
+      commitMessage({
+        type,
+        jira,
+        subject,
+        body,
+        breaking,
+        issues
+      },
+        { ...defaultOptions, exclamationMark: true })
+    ).to.equal(
+      `${type}!: ${jira} ${subject}\n\n${body}\n\n${breakingChange}${breaking}\n\n${issues}`
+    );
+  });
   it('skip jira task when optional', function() {
     expect(
       commitMessage(

--- a/index.js
+++ b/index.js
@@ -69,7 +69,12 @@ const options = {
   jiraAppend:
     process.env.CZ_JIRA_APPEND ||
     config.jiraAppend ||
-    defaults.jiraAppend
+    defaults.jiraAppend,
+    exclamationMark: getEnvOrConfig(
+      process.env.CZ_EXCLAMATION_MARK,
+      config.exclamationMark,
+      defaults.exclamationMark
+    )
 };
 
 (function(options) {


### PR DESCRIPTION
See #45.

This PR adds the option to automatically append an exclamation mark (!) after the scope in case there is a breaking change.
This is opt-in and must be activated via the env variable `CZ_EXCLAMATION_MARK` or the configuration option `exclamationMark`.

Including the exclamation mark improves the visibility of breaking changes by making them visible in the commit message header. To ensure this change is non-breaking the feature is opt-in.