### PR TITLE
feat: Add confirmScope option

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -4,6 +4,7 @@ module.exports = {
   types: conventionalCommitTypes,
   jiraMode: true,
   skipScope: true,
+  confirmScope: false,
   maxHeaderWidth: 72,
   minHeaderWidth: 2,
   maxLineWidth: 100,

--- a/engine.js
+++ b/engine.js
@@ -121,9 +121,21 @@ module.exports = function(options) {
           }
         },
         {
+          type: 'confirm',
+          name: 'confirmScope',
+          when: options.confirmScope && hasScopes && !options.skipScope,
+          message:
+            options.confirmScopeMessage || 'Does this commit have a scope?',
+        },
+        {
           type: hasScopes ? 'list' : 'input',
           name: 'scope',
-          when: !options.skipScope,
+          when: function(answers) {
+            return (
+              !options.skipScope &&
+              (answers.confirmScope || !options.confirmScope)
+            );
+          },
           choices: hasScopes ? options.scopes : undefined,
           message:
             'What is the scope of this change (e.g. component or file name): ' +

--- a/index.js
+++ b/index.js
@@ -29,6 +29,16 @@ const options = {
     config.skipScope,
     defaults.skipScope
   ),
+  confirmScope: getEnvOrConfig(
+    process.env.CZ_CONFIRM_SCOPE,
+    config.confirmScope,
+    defaults.confirmScope
+  ),
+  confirmScopeMessage: getEnvOrConfig(
+    process.env.CZ_CONFIRM_SCOPE_MESSAGE,
+    config.confirmScopeMessage,
+    undefined
+  ),
   defaultType: process.env.CZ_TYPE || config.defaultType,
   defaultScope: process.env.CZ_SCOPE || config.defaultScope,
   defaultSubject: process.env.CZ_SUBJECT || config.defaultSubject,


### PR DESCRIPTION
This enables a prompt prior to selecting a scope from a list, to allow for commits that do not have
a scope that matches the ones provided.

re #47