### PR TITLE
fix: Update command used to determine branch name

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
   const minHeaderWidth = getFromOptionsOrDefaults('minHeaderWidth');
   const maxHeaderWidth = getFromOptionsOrDefaults('maxHeaderWidth');
 
-  const branchName = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  const branchName = execSync('git branch --show-current').toString().trim();
   const jiraIssueRegex = /(?<jiraIssue>(?<!([A-Z0-9]{1,10})-?)[A-Z0-9]+-\d+)/;
   const matchResult = branchName.match(jiraIssueRegex);
   const jiraIssue =


### PR DESCRIPTION
We use `configurable.js` to build a customized config for Commitizen that we use across all projects in our org. The problem we have encountered happens when a dev creates a new repo, then tries to make a commit which spins up Commitizen with our custom config. The error we get is:

```
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Command failed: git rev-parse --abbrev-ref HEAD
```

I have narrowed it down to the line changed in this PR. 

* Running `git rev-parse --abbrev-ref HEAD` directly in a fresh repo that doesn't have any commits yet throws the error we see when Commitizen spins up. 
* The command I updated it to will return the same value, but doesn't throw in a new repo. This updated command was introduced in Git `2.22.0` which was released in 2019, so I think it's safe to use since most devs wouldn't have any reason _not_ to use somewhat up-to-date versions of Git.

Thanks go to the author of [this StackOverflow answer](https://stackoverflow.com/a/6245587/5072076)