### PR TITLE
feat: add inquirer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "boxen": "^5.0.0",
     "chalk": "^2.4.1",
     "commitizen": "^4.2.4",
+    "inquirer": "^6.5.2",
     "lodash.map": "^4.5.1",
     "longest": "^2.0.1",
     "right-pad": "^1.0.1",


### PR DESCRIPTION
Seems it didn't need any changes to package-lock which I thought was interesting.

This fixes use of this package for yarn pnp.