### PR TITLE
New jiraLocation option for "footer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,26 +43,57 @@ and then add the following to package.json:
 
 Like commitizen, you can specify the configuration of cz-conventional-changelog-for-jira through the package.json's `config.commitizen` key, or with environment variables.
 
-| Environment variable | package.json   | Default           | Description                                                                                                                                                           |
-| -------------------- | -------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CZ_JIRA_MODE         | jiraMode       | true              | If this is set to true, CZ will ask for a Jira issue and put it in the commit head. If set to false CZ will ask for the issue in the end, and can be used for GitHub. |
-| CZ_MAX_HEADER_WIDTH  | maxHeaderWidth | 72                | This limits how long a commit message head can be.                                                                                                                    |
-| CZ_MIN_HEADER_WIDTH  | minHeaderWidth | 2                 | This limits how short a commit message can be.                                                                                                                        |
-| CZ_MAX_LINE_WIDTH    | maxLineWidth   | 100               | Commit message bodies are automatically wrapped. This decides how long the lines will be.                                                                             |
-| CZ_SKIP_SCOPE        | skipScope      | true              | If scope should be used in commit messages.                                                                                                                           |
-|                      | scopes         | undefined         | A list (JS Array) of scopes that will be available for selection. Note that adding this will change the scope field from Inquirer 'input' to 'list'.                  |
-| CZ_TYPE              | defaultType    | undefined         | The default type.                                                                                                                                                     |
-| CZ_SCOPE             | defaultScope   | undefined         | The default scope.                                                                                                                                                    |
-| CZ_CUSTOM_SCOPE      | customScope    | false             | Whether user can provide custom scope in addition to predefined ones
-| CZ_SUBJECT           | defaultSubject | undefined         | A default subject.                                                                                                                                                    |
-| CZ_BODY              | defaultBody    | undefined         | A default body.                                                                                                                                                       |
-| CZ_ISSUES            | defaultIssues  | undefined         | A default issue.                                                                                                                                                      |
-| CZ_JIRA_OPTIONAL     | jiraOptional   | false             | If this is set to true, you can leave the JIRA field blank.                                                                                                           |
-| CZ_JIRA_PREFIX       | jiraPrefix     | "DAZ"             | If this is set it will be will be displayed as the default JIRA ticket prefix                                                                                         |
-| CZ_JIRA_LOCATION     | jiraLocation   | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`                                                                               |
-| CZ_JIRA_PREPEND      | jiraPrepend    | ""                | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                        |
-| CZ_JIRA_APPEND       | jiraAppend     | ""                | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                         |
-| CZ_EXCLAMATION_MARK  | exclamationMark| false             | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1.  |
+| Environment variable | package.json    | Default           | Description                                                                                                                                                             |
+|----------------------|-----------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| CZ_JIRA_MODE         | jiraMode        | true              | If this is set to true, CZ will ask for a Jira issue and put it in the commit head. If set to false CZ will ask for the issue in the end, and can be used for GitHub.   |
+| CZ_MAX_HEADER_WIDTH  | maxHeaderWidth  | 72                | This limits how long a commit message head can be.                                                                                                                      |
+| CZ_MIN_HEADER_WIDTH  | minHeaderWidth  | 2                 | This limits how short a commit message can be.                                                                                                                          |
+| CZ_MAX_LINE_WIDTH    | maxLineWidth    | 100               | Commit message bodies are automatically wrapped. This decides how long the lines will be.                                                                               |
+| CZ_SKIP_SCOPE        | skipScope       | true              | If scope should be used in commit messages.                                                                                                                             |
+|                      | scopes          | undefined         | A list (JS Array) of scopes that will be available for selection. Note that adding this will change the scope field from Inquirer 'input' to 'list'.                    |
+| CZ_TYPE              | defaultType     | undefined         | The default type.                                                                                                                                                       |
+| CZ_SCOPE             | defaultScope    | undefined         | The default scope.                                                                                                                                                      |
+| CZ_CUSTOM_SCOPE      | customScope     | false             | Whether user can provide custom scope in addition to predefined ones                                                                                                    |
+| CZ_SUBJECT           | defaultSubject  | undefined         | A default subject.                                                                                                                                                      |
+| CZ_BODY              | defaultBody     | undefined         | A default body.                                                                                                                                                         |
+| CZ_ISSUES            | defaultIssues   | undefined         | A default issue.                                                                                                                                                        |
+| CZ_JIRA_OPTIONAL     | jiraOptional    | false             | If this is set to true, you can leave the JIRA field blank.                                                                                                             |
+| CZ_JIRA_PREFIX       | jiraPrefix      | "DAZ"             | If this is set it will be will be displayed as the default JIRA ticket prefix                                                                                           |
+| CZ_JIRA_LOCATION     | jiraLocation    | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`, `post-body`                                                                    |
+| CZ_JIRA_PREPEND      | jiraPrepend     | ""                | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                          |
+| CZ_JIRA_APPEND       | jiraAppend      | ""                | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                           |
+| CZ_EXCLAMATION_MARK  | exclamationMark | false             | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1. |
+
+### Jira Location Options
+
+pre-type:
+```text
+JIRA-1234 type(scope): commit subject
+```
+
+pre-description:
+```text
+type(scope): JIRA-1234 commit subject
+```
+
+post-description:
+```text
+type(scope): commit subject JIRA-1234
+```
+
+post-body:
+```text
+type(scope): commit subject
+
+JIRA-1234
+```
+```text
+type(scope): commit subject
+
+this is a commit body
+
+JIRA-1234
+```
 
 ## Dynamic Configuration
 
@@ -104,27 +135,28 @@ This example would:
 * Limit the scope selection to either `myScope` or `myScope2`
 
 List of all supported configurable options when using the _configurable_ approach:
-| Key            | Default                  | Description                                                                                                                                                           |
-| -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| jiraMode       | true                     | If this is set to true, CZ will ask for a Jira issue and put it in the commit head. If set to false CZ will ask for the issue in the end, and can be used for GitHub. |
-| maxHeaderWidth | 72                       | This limits how long a commit message head can be.                                                                                                                    |
-| minHeaderWidth | 2                        | This limits how short a commit message can be.                                                                                                                        |
-| maxLineWidth   | 100                      | Commit message bodies are automatically wrapped. This decides how long the lines will be.                                                                             |
-| skipScope      | true                     | If scope should be used in commit messages.                                                                                                                           |
-| defaultType    | undefined                | The default type.                                                                                                                                                     |
-| defaultScope   | undefined                | The default scope.                                                                                                                                                    |
-| defaultSubject | undefined                | A default subject.                                                                                                                                                    |
-| defaultBody    | undefined                | A default body.                                                                                                                                                       |
-| defaultIssues  | undefined                | A default issue.                                                                                                                                                      |
-| jiraPrefix     | 'DAZ'                    | The default JIRA ticket prefix that will be displayed.                                                                                                                |
-| types          | ./types.js               | A list (JS Object) of supported commit types.                                                                                                                         |
-| scopes         | undefined                | A list (JS Array) of scopes that will be available for selection. Note that adding this will change the scope field from Inquirer 'input' to 'list'.                  |
-| customScope    | false                    | If this is set to true, users are given an option to provide custom scope aside the ones predefined in 'scopes' array. In this case a new option named 'custom' appears in the list and once chosen a prompt appears to provide custom scope
-| jiraOptional   | false                    | If this is set to true, you can leave the JIRA field blank.                                                                                                           |
-| jiraLocation   | "pre-description"        | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`                                                                               |
-| jiraPrepend    | ""                       | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                        |
-| jiraAppend     | ""                       | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                         |
-| exclamationMark| false                    | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1.  |
+
+| Key             | Default           | Description                                                                                                                                                                                                                                  |
+|-----------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| jiraMode        | true              | If this is set to true, CZ will ask for a Jira issue and put it in the commit head. If set to false CZ will ask for the issue in the end, and can be used for GitHub.                                                                        |
+| maxHeaderWidth  | 72                | This limits how long a commit message head can be.                                                                                                                                                                                           |
+| minHeaderWidth  | 2                 | This limits how short a commit message can be.                                                                                                                                                                                               |
+| maxLineWidth    | 100               | Commit message bodies are automatically wrapped. This decides how long the lines will be.                                                                                                                                                    |
+| skipScope       | true              | If scope should be used in commit messages.                                                                                                                                                                                                  |
+| defaultType     | undefined         | The default type.                                                                                                                                                                                                                            |
+| defaultScope    | undefined         | The default scope.                                                                                                                                                                                                                           |
+| defaultSubject  | undefined         | A default subject.                                                                                                                                                                                                                           |
+| defaultBody     | undefined         | A default body.                                                                                                                                                                                                                              |
+| defaultIssues   | undefined         | A default issue.                                                                                                                                                                                                                             |
+| jiraPrefix      | 'DAZ'             | The default JIRA ticket prefix that will be displayed.                                                                                                                                                                                       |
+| types           | ./types.js        | A list (JS Object) of supported commit types.                                                                                                                                                                                                |
+| scopes          | undefined         | A list (JS Array) of scopes that will be available for selection. Note that adding this will change the scope field from Inquirer 'input' to 'list'.                                                                                         |
+| customScope     | false             | If this is set to true, users are given an option to provide custom scope aside the ones predefined in 'scopes' array. In this case a new option named 'custom' appears in the list and once chosen a prompt appears to provide custom scope |
+| jiraOptional    | false             | If this is set to true, you can leave the JIRA field blank.                                                                                                                                                                                  |
+| jiraLocation    | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`, `post-body`                                                                                                                                         |
+| jiraPrepend     | ""                | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                                                                                               |
+| jiraAppend      | ""                | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                                                                                                |
+| exclamationMark | false             | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1.                                                                      |
 
 
 ### Commitlint

--- a/engine.js
+++ b/engine.js
@@ -42,6 +42,9 @@ module.exports = function(options) {
       case 'post-description':
         return type + scope + ': ' + subject + ' ' + jiraWithDecorators;
         break;
+      case 'footer':
+        return type + scope + ': ' + subject;
+        break;
       default:
         return type + scope + ': ' + jiraWithDecorators + subject;
     }
@@ -262,7 +265,12 @@ module.exports = function(options) {
           : '';
         breaking = breaking ? wrap(breaking, wrapOptions) : false;
 
-        var issues = answers.issues ? wrap(answers.issues, wrapOptions) : false;
+        var issues;
+        if (options.jiraMode && options.jiraLocation === 'footer') {
+          issues = jiraWithDecorators.trim();
+        } else {
+          issues = answers.issues ? wrap(answers.issues, wrapOptions) : false;
+        }
 
         const fullCommit = filter([head, body, breaking, issues]).join('\n\n');
 

--- a/engine.js
+++ b/engine.js
@@ -155,7 +155,7 @@ module.exports = function(options) {
           default: options.defaultSubject,
           maxLength: maxHeaderWidth - (options.exclamationMark ? 1 : 0),
           leadingLabel: answers => {
-            const jira = answers.jira ? ` ${answers.jira}` : '';
+            const jira = answers.jira && options.jiraLocation !== 'footer' ? ` ${answers.jira}` : '';
 
             let scope = '';
             const providedScope = getProvidedScope(answers);

--- a/engine.js
+++ b/engine.js
@@ -42,7 +42,7 @@ module.exports = function(options) {
       case 'post-description':
         return type + scope + ': ' + subject + ' ' + jiraWithDecorators;
         break;
-      case 'footer':
+      case 'post-body':
         return type + scope + ': ' + subject;
         break;
       default:
@@ -257,6 +257,14 @@ module.exports = function(options) {
 
         // Wrap these lines at options.maxLineWidth characters
         var body = answers.body ? wrap(answers.body, wrapOptions) : false;
+        if (options.jiraMode && options.jiraLocation === 'post-body') {
+          if (body === false) {
+            body = '';
+          } else {
+            body += "\n\n";
+          }
+          body += jiraWithDecorators.trim();
+        }
 
         // Apply breaking change prefix, removing it if already present
         var breaking = answers.breaking ? answers.breaking.trim() : '';
@@ -265,12 +273,7 @@ module.exports = function(options) {
           : '';
         breaking = breaking ? wrap(breaking, wrapOptions) : false;
 
-        var issues;
-        if (options.jiraMode && options.jiraLocation === 'footer') {
-          issues = jiraWithDecorators.trim();
-        } else {
-          issues = answers.issues ? wrap(answers.issues, wrapOptions) : false;
-        }
+        var issues = answers.issues ? wrap(answers.issues, wrapOptions) : false;
 
         const fullCommit = filter([head, body, breaking, issues]).join('\n\n');
 

--- a/engine.test.js
+++ b/engine.test.js
@@ -351,6 +351,34 @@ describe('commit message', function() {
       )
     ).to.equal(`${type}(${scope}): ${subject} ${jira} \n\n${body}`);
   });
+  it('footer jiraLocation', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body
+        },
+        { jiraMode: true, jiraLocation: 'footer' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject}\n\n${body}\n\n${jira}`);
+  });
+  it('footer jiraLocation no body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body: false
+        },
+        { jiraMode: true, jiraLocation: 'footer' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject}\n\n${jira}`);
+  });
   it('jiraPrepend decorator', function() {
     expect(
       commitMessage(

--- a/engine.test.js
+++ b/engine.test.js
@@ -351,7 +351,7 @@ describe('commit message', function() {
       )
     ).to.equal(`${type}(${scope}): ${subject} ${jira} \n\n${body}`);
   });
-  it('footer jiraLocation', function() {
+  it('post-body jiraLocation with body', function() {
     expect(
       commitMessage(
         {
@@ -361,11 +361,11 @@ describe('commit message', function() {
           subject,
           body
         },
-        { jiraMode: true, jiraLocation: 'footer' }
+        { ...defaultOptions, jiraLocation: 'post-body' }
       )
     ).to.equal(`${type}(${scope}): ${subject}\n\n${body}\n\n${jira}`);
   });
-  it('footer jiraLocation no body', function() {
+  it('post-body jiraLocation no body', function() {
     expect(
       commitMessage(
         {
@@ -375,9 +375,25 @@ describe('commit message', function() {
           subject,
           body: false
         },
-        { jiraMode: true, jiraLocation: 'footer' }
+        { ...defaultOptions, jiraLocation: 'post-body' }
       )
     ).to.equal(`${type}(${scope}): ${subject}\n\n${jira}`);
+  });
+  it('post-body jiraLocation with body and footer', function() {
+    var footer = `${breakingChange}${breaking}`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body,
+          breaking,
+        },
+        { ...defaultOptions, jiraLocation: 'post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject}\n\n${body}\n\n${jira}\n\n${breakingChange}${breaking}`);
   });
   it('jiraPrepend decorator', function() {
     expect(


### PR DESCRIPTION
This request is an effort to format the commit message so they better align with the https://github.com/semantic-release/release-notes-generator plugin for semantic-release.  This is allow the semantic-release plugin to find the Jira ID in the footer of the commit message and build the appropriate links back to Jira in the release nots.