### PR TITLE
Increment node version in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
After upgrading dependencies' versions, the Github Action for release fails because of the NodeJS version used during the process. This PR increments the NodeJS version to fix it.

This change was requested after the dependencies' versions PR was merged. See https://github.com/digitalroute/cz-conventional-changelog-for-jira/pull/63#issuecomment-1210714120