### PR TITLE
feat: add post-body jiraLocation

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -36,6 +36,9 @@ module.exports = function(options) {
       case 'pre-type':
         return jiraWithDecorators + type + scope + ': ' + subject;
         break;
+      case 'post-type':
+        return type + scope + jiraWithDecorators + ': ' + subject;
+        break;
       case 'pre-description':
         return type + scope + ': ' + jiraWithDecorators + subject;
         break;
@@ -250,9 +253,14 @@ module.exports = function(options) {
         scope = addExclamationMark ? scope + '!' : scope;
 
         // Get Jira issue prepend and append decorators
-        var prepend = options.jiraPrepend || ''
-        var append = options.jiraAppend || ''
-        var jiraWithDecorators = answers.jira ? prepend + answers.jira + append + ' ': '';
+        const [space_before, space_after] =
+          options.jiraLocation == 'post-type' ? [' ', ''] : ['', ' '];
+        var prepend = options.jiraPrepend || space_before;
+        var append = options.jiraAppend || space_after;
+
+        var jiraWithDecorators = answers.jira
+          ? prepend + answers.jira + append
+          : '';
 
         // Hard limit this line in the validate
         const head = getJiraIssueLocation(options.jiraLocation, answers.type, scope, jiraWithDecorators, answers.subject);

--- a/engine.test.js
+++ b/engine.test.js
@@ -324,6 +324,34 @@ describe('commit message', function() {
       )
     ).to.equal(`${jiraUpperCase} ${type}(${scope}): ${subject}\n\n${body}`);
   });
+  it('post-type jiraLocation without scope', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope: null,
+          jira,
+          subject,
+          body
+        },
+        { jiraLocation: 'post-type' }
+      )
+    ).to.equal(`${type} ${jiraUpperCase}: ${subject}\n\n${body}`);
+  });
+  it('post-type jiraLocation with scope', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body
+        },
+        { jiraLocation: 'post-type' }
+      )
+    ).to.equal(`${type}(${scope}) ${jiraUpperCase}: ${subject}\n\n${body}`);
+  });
   it('pre-description jiraLocation', function() {
     expect(
       commitMessage(
@@ -420,7 +448,7 @@ describe('commit message', function() {
           subject,
           body
         },
-        { jiraAppend: '+' }
+        { jiraAppend: '+ ' }
       )
     ).to.equal(`${type}(${scope}): ${jiraUpperCase}+ ${subject}\n\n${body}`);
   });
@@ -435,7 +463,7 @@ describe('commit message', function() {
           body
         },
         {
-          jiraAppend: ']',
+          jiraAppend: '] ',
           jiraPrepend: '['
         }
       )
@@ -452,7 +480,7 @@ describe('commit message', function() {
           body
         },
         {
-          jiraAppend: ']',
+          jiraAppend: '] ',
           jiraPrepend: '[',
           jiraLocation: 'pre-type'
         }


### PR DESCRIPTION
This comes with a bit of complexity. Previously we were automatically appending a space to the jira
part. However by moving it here, we actually wish to have the space at the start. This then adds
complications with the jiraPrepend and jiraAppend options, and thus causes a breaking change.

BREAKING CHANGE: Existing jiraAppend options will need to add an extra space to maintain
functionality