### PR TITLE
add three new jiraLocations to support having jira ticket in both the header and the footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Like commitizen, you can specify the configuration of cz-conventional-changelog-
 | CZ_ISSUES            | defaultIssues   | undefined         | A default issue.                                                                                                                                                        |
 | CZ_JIRA_OPTIONAL     | jiraOptional    | false             | If this is set to true, you can leave the JIRA field blank.                                                                                                             |
 | CZ_JIRA_PREFIX       | jiraPrefix      | "DAZ"             | If this is set it will be will be displayed as the default JIRA ticket prefix                                                                                           |
-| CZ_JIRA_LOCATION     | jiraLocation    | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`, `post-body`                                                                    |
+| CZ_JIRA_LOCATION     | jiraLocation    | "pre-description" | Changes position of JIRA ID. Options: `pre-type`, `pre-description`, `post-description`, `post-body`, `pre-type-and-post-body`, `pre-description-and-post-body`, `post-description-and-post-body` |
 | CZ_JIRA_PREPEND      | jiraPrepend     | ""                | Prepends JIRA ID with an optional decorator. e.g.: `[DAZ-1234`                                                                                                          |
 | CZ_JIRA_APPEND       | jiraAppend      | ""                | Appends JIRA ID with an optional decorator. e.g.: `DAZ-1234]`                                                                                                           |
 | CZ_EXCLAMATION_MARK  | exclamationMark | false             | On breaking changes, adds an exclamation mark (!) after the scope, e.g.: `type(scope)!: break stuff`. When activated, reduces the effective allowed header length by 1. |
@@ -93,6 +93,48 @@ JIRA-1234
 ```
 ```text
 type(scope): commit subject
+
+this is a commit body
+
+JIRA-1234
+```
+
+pre-type-and-post-body:
+```text
+JIRA-1234 type(scope): commit subject
+
+JIRA-1234
+```
+```text
+JIRA-1234 type(scope): commit subject
+
+this is a commit body
+
+JIRA-1234
+```
+
+pre-description-and-post-body:
+```text
+type(scope): JIRA-1234 commit subject
+
+JIRA-1234
+```
+```text
+type(scope): JIRA-1234 commit subject
+
+this is a commit body
+
+JIRA-1234
+```
+
+post-description-and-post-body:
+```text
+type(scope): commit subject JIRA-1234
+
+JIRA-1234
+```
+```text
+type(scope): commit subject JIRA-1234 
 
 this is a commit body
 

--- a/engine.js
+++ b/engine.js
@@ -34,12 +34,15 @@ module.exports = function(options) {
   var getJiraIssueLocation = function(location, type, scope, jiraWithDecorators, subject) {
     switch(location) {
       case 'pre-type':
+      case 'pre-type-and-post-body':
         return jiraWithDecorators + type + scope + ': ' + subject;
         break;
       case 'pre-description':
+      case 'pre-description-and-post-body':
         return type + scope + ': ' + jiraWithDecorators + subject;
         break;
       case 'post-description':
+      case 'post-description-and-post-body':
         return type + scope + ': ' + subject + ' ' + jiraWithDecorators;
         break;
       case 'post-body':
@@ -259,7 +262,7 @@ module.exports = function(options) {
 
         // Wrap these lines at options.maxLineWidth characters
         var body = answers.body ? wrap(answers.body, wrapOptions) : false;
-        if (options.jiraMode && options.jiraLocation === 'post-body') {
+        if (options.jiraMode && options.jiraLocation.endsWith('post-body')) {
           if (body === false) {
             body = '';
           } else {

--- a/engine.test.js
+++ b/engine.test.js
@@ -396,6 +396,138 @@ describe('commit message', function() {
       )
     ).to.equal(`${type}(${scope}): ${subject}\n\n${body}\n\n${jiraUpperCase}\n\n${breakingChange}${breaking}`);
   });
+  it('pre-type-and-post-body jiraLocation with body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body
+        },
+        { ...defaultOptions, jiraLocation: 'pre-type-and-post-body' }
+      )
+    ).to.equal(`${jiraUpperCase} ${type}(${scope}): ${subject}\n\n${body}\n\n${jiraUpperCase}`);
+  });
+  it('pre-type-and-post-body jiraLocation no body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body: false
+        },
+        { ...defaultOptions, jiraLocation: 'pre-type-and-post-body' }
+      )
+    ).to.equal(`${jiraUpperCase} ${type}(${scope}): ${subject}\n\n${jiraUpperCase}`);
+  });
+  it('pre-type-and-post-body jiraLocation with body and footer', function() {
+    var footer = `${breakingChange}${breaking}`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body,
+          breaking,
+        },
+        { ...defaultOptions, jiraLocation: 'pre-type-and-post-body' }
+      )
+    ).to.equal(`${jiraUpperCase} ${type}(${scope}): ${subject}\n\n${body}\n\n${jiraUpperCase}\n\n${breakingChange}${breaking}`);
+  });
+  it('pre-description-and-post-body jiraLocation with body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body
+        },
+        { ...defaultOptions, jiraLocation: 'pre-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${jiraUpperCase} ${subject}\n\n${body}\n\n${jiraUpperCase}`);
+  });
+  it('pre-description-and-post-body jiraLocation no body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body: false
+        },
+        { ...defaultOptions, jiraLocation: 'pre-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${jiraUpperCase} ${subject}\n\n${jiraUpperCase}`);
+  });
+  it('pre-descripition-and-post-body jiraLocation with body and footer', function() {
+    var footer = `${breakingChange}${breaking}`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body,
+          breaking,
+        },
+        { ...defaultOptions, jiraLocation: 'pre-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${jiraUpperCase} ${subject}\n\n${body}\n\n${jiraUpperCase}\n\n${breakingChange}${breaking}`);
+  });
+  it('post-description-and-post-body jiraLocation with body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body
+        },
+        { ...defaultOptions, jiraLocation: 'post-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject} ${jiraUpperCase} \n\n${body}\n\n${jiraUpperCase}`);
+  });
+  it('post-description-and-post-body jiraLocation no body', function() {
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body: false
+        },
+        { ...defaultOptions, jiraLocation: 'post-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject} ${jiraUpperCase} \n\n${jiraUpperCase}`);
+  });
+  it('post-description-and-post-body jiraLocation with body and footer', function() {
+    var footer = `${breakingChange}${breaking}`;
+    expect(
+      commitMessage(
+        {
+          type,
+          scope,
+          jira,
+          subject,
+          body,
+          breaking,
+        },
+        { ...defaultOptions, jiraLocation: 'post-description-and-post-body' }
+      )
+    ).to.equal(`${type}(${scope}): ${subject} ${jiraUpperCase} \n\n${body}\n\n${jiraUpperCase}\n\n${breakingChange}${breaking}`);
+  });
   it('jiraPrepend decorator', function() {
     expect(
       commitMessage(


### PR DESCRIPTION
add pre-type-and-post-body, pre-description-and-post-body, and post-description-and-post-body as options to jiraLocation.
When either of these new locations are selected the jira ticket will appear in two places in the commit message, once in the header (pre-type, pre-description, post-description.

i.e:

pre-type-and-post-body:
```text
JIRA-1234 type(scope): commit subject

JIRA-1234
```
```text
JIRA-1234 type(scope): commit subject

this is a commit body

JIRA-1234
```

pre-description-and-post-body:
```text
type(scope): JIRA-1234 commit subject

JIRA-1234
```
```text
type(scope): JIRA-1234 commit subject

this is a commit body

JIRA-1234
```

post-description-and-post-body:
```text
type(scope): commit subject JIRA-1234

JIRA-1234
```
```text
type(scope): commit subject JIRA-1234 

this is a commit body

JIRA-1234
```

closes: #68